### PR TITLE
Update SYNTAX_REGEX to ignore anchor targets

### DIFF
--- a/src/models/stimulus_syntax.ts
+++ b/src/models/stimulus_syntax.ts
@@ -1,4 +1,4 @@
-export const SYNTAX_REGEXP = /(controller|target|action)\s*[:=]\s*["']([a-zA-Z0-9_\-\.>#:@ ]*)["']?/;
+export const SYNTAX_REGEXP = /(controller|target|action)\s*[:=]\s*["']([^_][a-zA-Z0-9_\-\.>#:@ ]*)["']?/;
 
 export const EVENT_SEPARATOR = '->';
 export const ACTION_SEPARATOR = '#';


### PR DESCRIPTION
Fixes #186 

Adjusts the `SYNTAX_REGEX` to ignore anchor targets, which all begin with an underscore.

```
target="_blank"
target="_parent"
target="_self"
target="_top"
```

which are not valid target values for Stimulus :)